### PR TITLE
Support wildcards correctly

### DIFF
--- a/serialization-processor/src/main/java/org/gwtproject/rpc/serial/processor/SerializableTypeOracleBuilder.java
+++ b/serialization-processor/src/main/java/org/gwtproject/rpc/serial/processor/SerializableTypeOracleBuilder.java
@@ -938,7 +938,11 @@ public class SerializableTypeOracleBuilder {
 
         if (type.getKind() == TypeKind.WILDCARD) {
             WildcardType wildcard = (WildcardType) type;
-            boolean success = computeTypeInstantiability(/*localLogger, */wildcard.getExtendsBound(), path, problems)
+            TypeMirror extendsBound = wildcard.getExtendsBound();
+            if (extendsBound == null) {
+                extendsBound = types.getJavaLangObject().asType();
+            }
+            boolean success = computeTypeInstantiability(/*localLogger, */extendsBound, path, problems)
                     .hasInstantiableSubtypes();
             tic = ensureTypeInfoComputed(type, path);
             tic.setInstantiableSubtypes(success);
@@ -1299,7 +1303,11 @@ public class SerializableTypeOracleBuilder {
                                       TypeMirror typeArg, TypePath parent, ProblemReport problems) {
         if (typeArg.getKind() == TypeKind.WILDCARD) {
             WildcardType isWildcard = (WildcardType) typeArg;
-            return checkTypeArgument(baseType, paramIndex, isWildcard.getExtendsBound(), parent,
+            TypeMirror bounds = isWildcard.getExtendsBound();
+            if (bounds == null) {
+                bounds = types.getJavaLangObject().asType();
+            }
+            return checkTypeArgument(baseType, paramIndex, bounds, parent,
                     problems);
         }
 

--- a/serialization-processor/src/main/java/org/gwtproject/rpc/serial/processor/TypeConstrainer.java
+++ b/serialization-processor/src/main/java/org/gwtproject/rpc/serial/processor/TypeConstrainer.java
@@ -219,7 +219,11 @@ public class TypeConstrainer {
 //        }
 
         if (type2.getKind() == TypeKind.WILDCARD) {
-            return typesMatch(type1, ((WildcardType)type2).getExtendsBound(), constraints);
+            TypeMirror extendsBound = ((WildcardType) type2).getExtendsBound();
+            if (extendsBound == null) {
+                extendsBound = types.getJavaLangObject().asType();
+            }
+            return typesMatch(type1, extendsBound, constraints);
         }
 //        JWildcardType type2Wild = type2.isWildcard();
 //        if (type2Wild != null) {


### PR DESCRIPTION
This is a bad idea to do in real types where generics affect what can be serialized, but may still be a necessary way to handle cases where a type's generics are unrelated to its serializable fields.